### PR TITLE
chore: swift-tools-version 6.0, iOS floor 18

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,9 @@ let package = Package(
         )
     ],
     targets: [
+        // ponytail: every target pinned to Swift 5 semantics. tools-version 6.0 is here
+        // for `.iOS(.v18)`, not for a concurrency migration — `TrackingEngineFacade.logger`
+        // is a mutable static, which Swift 6 rejects outright. Drop these to adopt Swift 6.
         .target(
             name: "TrackingEngineCore",
             dependencies: [],

--- a/Package.swift
+++ b/Package.swift
@@ -1,34 +1,51 @@
-// swift-tools-version:5.5
+// swift-tools-version:6.0
 import PackageDescription
 
 let package = Package(
     name: "TrackingEngine",
-    platforms: [.iOS(.v15)],
+    platforms: [.iOS(.v18)],
     products: [
-        .library(name: "TrackingEngine", targets: ["TrackingEngine"]),
-        .library(name: "TrackingEngineCore", targets: ["TrackingEngineCore"]),
+        .library(
+            name: "TrackingEngine",
+            targets: ["TrackingEngine"]
+        ),
+        .library(
+            name: "TrackingEngineCore",
+            targets: ["TrackingEngineCore"]
+        ),
     ],
     dependencies: [
-        .package(name: "Firebase",
-                 url: "https://github.com/firebase/firebase-ios-sdk.git",
-                 .upToNextMajor(from: "12.0.0"))
+        .package(
+            name: "Firebase",
+            url: "https://github.com/firebase/firebase-ios-sdk.git",
+            .upToNextMajor(from: "12.0.0")
+        )
     ],
     targets: [
         .target(
             name: "TrackingEngineCore",
-            dependencies: []
+            dependencies: [],
+            swiftSettings: [.swiftLanguageMode(.v5)]
         ),
         .target(
             name: "TrackingEngine",
             dependencies: [
                 "TrackingEngineCore",
-                .product(name: "FirebaseAnalytics", package: "Firebase"),
-                .product(name: "FirebaseCrashlytics", package: "Firebase")
-            ]
+                .product(
+                    name: "FirebaseAnalytics",
+                    package: "Firebase"
+                ),
+                .product(
+                    name: "FirebaseCrashlytics",
+                    package: "Firebase"
+                )
+            ],
+            swiftSettings: [.swiftLanguageMode(.v5)]
         ),
         .testTarget(
             name: "TrackingEngineTests",
-            dependencies: ["TrackingEngine", "TrackingEngineCore"]
+            dependencies: ["TrackingEngine", "TrackingEngineCore"],
+            swiftSettings: [.swiftLanguageMode(.v5)]
         ),
     ]
 )


### PR DESCRIPTION
## Summary

Raises the package to `swift-tools-version: 6.0` and `platforms: [.iOS(.v18)]`, matching MatchWords' deployment target (raised to iOS 18 in mchirino89/MatchWord#115).

## Why 6.0

`.iOS(.v18)` is only expressible from tools-version 6.0 — older manifests fail resolution with `'v18' is unavailable ... was introduced in PackageDescription 6.0`, before compiling a line.

## Why Swift 5 language mode

tools-version 6.0 defaults to **Swift 6 language mode**, and this package does not pass it: `TrackingEngineFacade.logger` is a `public static var`, which strict concurrency rejects outright. That is a genuine API question — the facade's whole design is a mutable global — not something to resolve inside a platform bump.

All three targets carry `swiftSettings: [.swiftLanguageMode(.v5)]` with a `ponytail:` comment naming the upgrade path. Dropping those settings is what adopting Swift 6 looks like, and it starts with deciding what `logger` should become.

## Test plan

Verified through the consuming app rather than `swift build`: this package declares only an iOS platform, so a command-line build resolves for **macOS**, where its Firebase dependency floors don't line up. That failure is an artifact of the invocation, not the manifest.

- [x] `bundle exec fastlane test` in MatchWords, against all five updated packages: **176 tests / 0 failures**
- [ ] Confirm iOS 18 is the floor you want — it drops 15/16/17 for any future consumer

## Note

The second commit restores a `ponytail:` comment that `swift-format` deleted: placed immediately before the `targets:` label it vanished on commit, with no warning and no hunk pointing at it. Inside the array, above the first `.target(`, it survives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
