### PR TITLE
RemoteConfigFacade — feature flags over the Core/Firebase split

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -41,6 +41,10 @@ let package = Package(
                 .product(
                     name: "FirebaseCrashlytics",
                     package: "Firebase"
+                ),
+                .product(
+                    name: "FirebaseRemoteConfig",
+                    package: "Firebase"
                 )
             ],
             swiftSettings: [.swiftLanguageMode(.v5)]

--- a/Sources/TrackingEngine/RemoteConfigFacade+Firebase.swift
+++ b/Sources/TrackingEngine/RemoteConfigFacade+Firebase.swift
@@ -3,6 +3,10 @@ import FirebaseRemoteConfig
 import TrackingEngineCore
 
 extension RemoteConfigFacade {
+    /// Firebase's own minimum fetch interval, 12 hours. Public so a host passing
+    /// a DEBUG override doesn't have to restate the release value alongside it.
+    public static let defaultFetchInterval: TimeInterval = 12 * 60 * 60
+
     /// Wires Remote Config and starts a fetch. Call alongside
     /// `TrackingEngineFacade.setup()`; order between the two doesn't matter,
     /// both configure the Firebase app if nobody has yet.
@@ -11,7 +15,7 @@ extension RemoteConfigFacade {
     ///   - defaults: every flag key mapped to its baked-in value. Seeding these
     ///     is what makes an un-fetched read return the app's own default rather
     ///     than Remote Config's blanket `false`.
-    ///   - minimumFetchInterval: Firebase's own default is 12 hours, which is
+    ///   - minimumFetchInterval: defaults to `defaultFetchInterval`, which is
     ///     right for release and useless while developing — a console toggle
     ///     appears to do nothing for half a day. Pass `0` from DEBUG builds.
     ///     It lives here as an argument rather than a `#if DEBUG` because
@@ -19,7 +23,7 @@ extension RemoteConfigFacade {
     ///     defined in a package target, and the failure is silent either way.
     public static func setup(
         defaults: [String: Bool],
-        minimumFetchInterval: TimeInterval = 43_200
+        minimumFetchInterval: TimeInterval = defaultFetchInterval
     ) {
         if FirebaseApp.app() == nil {
             FirebaseApp.configure()

--- a/Sources/TrackingEngine/RemoteConfigFacade+Firebase.swift
+++ b/Sources/TrackingEngine/RemoteConfigFacade+Firebase.swift
@@ -1,0 +1,50 @@
+import Firebase
+import FirebaseRemoteConfig
+import TrackingEngineCore
+
+extension RemoteConfigFacade {
+    /// Wires Remote Config and starts a fetch. Call alongside
+    /// `TrackingEngineFacade.setup()`; order between the two doesn't matter,
+    /// both configure the Firebase app if nobody has yet.
+    ///
+    /// - Parameters:
+    ///   - defaults: every flag key mapped to its baked-in value. Seeding these
+    ///     is what makes an un-fetched read return the app's own default rather
+    ///     than Remote Config's blanket `false`.
+    ///   - minimumFetchInterval: Firebase's own default is 12 hours, which is
+    ///     right for release and useless while developing — a console toggle
+    ///     appears to do nothing for half a day. Pass `0` from DEBUG builds.
+    ///     It lives here as an argument rather than a `#if DEBUG` because
+    ///     `DEBUG` is reliably defined in the app target and merely usually
+    ///     defined in a package target, and the failure is silent either way.
+    public static func setup(
+        defaults: [String: Bool],
+        minimumFetchInterval: TimeInterval = 43_200
+    ) {
+        if FirebaseApp.app() == nil {
+            FirebaseApp.configure()
+        }
+
+        let remoteConfig = RemoteConfig.remoteConfig()
+        let settings = RemoteConfigSettings()
+        settings.minimumFetchInterval = minimumFetchInterval
+        remoteConfig.configSettings = settings
+        remoteConfig.setDefaults(defaults.mapValues { NSNumber(value: $0) })
+
+        // Assigned before the fetch, not in its completion: the resolver reads
+        // whatever Remote Config currently holds, so it answers from `defaults`
+        // now and from the console the moment activation lands. Waiting for the
+        // callback would leave every flag unreadable during launch and write a
+        // mutable static from a background queue for no gain.
+        configure(with: RemoteConfigResolver(remoteConfig: remoteConfig))
+
+        remoteConfig.fetchAndActivate { _, error in
+            if let error {
+                TrackingEngineFacade.log(
+                    errorName: "remoteConfigFetchFailed",
+                    parameters: ["description": error.localizedDescription]
+                )
+            }
+        }
+    }
+}

--- a/Sources/TrackingEngine/RemoteConfigResolver.swift
+++ b/Sources/TrackingEngine/RemoteConfigResolver.swift
@@ -1,0 +1,22 @@
+import FirebaseRemoteConfig
+import TrackingEngineCore
+
+struct RemoteConfigResolver: FlagResolving {
+    let remoteConfig: RemoteConfig
+
+    func isEnabled(
+        _ key: String,
+        default defaultValue: Bool
+    ) -> Bool {
+        let value = remoteConfig.configValue(forKey: key)
+
+        // `.static` means Remote Config has never heard of this key — neither
+        // fetched nor seeded. Its `boolValue` is `false` regardless, so reading
+        // it here would silently override a caller asking for `default: true`.
+        guard value.source != .static else {
+            return defaultValue
+        }
+
+        return value.boolValue
+    }
+}

--- a/Sources/TrackingEngineCore/FlagResolving.swift
+++ b/Sources/TrackingEngineCore/FlagResolving.swift
@@ -1,0 +1,11 @@
+/// Reads a remotely-controlled boolean flag. The flag analogue of
+/// `TrackingLoggable`: declared here, in the Firebase-free product, so a host
+/// app's call sites depend on this and never on Remote Config.
+public protocol FlagResolving {
+    /// - Parameter defaultValue: what to answer when the key is unknown or no
+    ///   fetch has landed yet. Resolvers must never invent a value.
+    func isEnabled(
+        _ key: String,
+        default defaultValue: Bool
+    ) -> Bool
+}

--- a/Sources/TrackingEngineCore/RemoteConfigFacade.swift
+++ b/Sources/TrackingEngineCore/RemoteConfigFacade.swift
@@ -1,0 +1,26 @@
+/// Firebase-free entry point for feature flags, mirroring `TrackingEngineFacade`.
+///
+/// `provider` stays `nil` until `setup(defaults:)` (in the `TrackingEngine`
+/// product) assigns one, and every read falls back to the caller's default
+/// meanwhile. That is what lets a test host link only `TrackingEngineCore`,
+/// never call `setup`, and still resolve every flag — with Firebase absent from
+/// the process, exactly as `logger == nil` does for analytics.
+public struct RemoteConfigFacade {
+    public static var provider: FlagResolving?
+
+    public static func configure(with provider: FlagResolving) {
+        Self.provider = provider
+    }
+
+    /// - Returns: the remote value, or `defaultValue` when no provider is wired
+    ///   or the provider has nothing for this key.
+    public static func isEnabled(
+        _ key: String,
+        default defaultValue: Bool
+    ) -> Bool {
+        provider?.isEnabled(
+            key,
+            default: defaultValue
+        ) ?? defaultValue
+    }
+}

--- a/Tests/TrackingEngineTests/FlagResolvingSpy.swift
+++ b/Tests/TrackingEngineTests/FlagResolvingSpy.swift
@@ -1,0 +1,20 @@
+import TrackingEngineCore
+
+final class FlagResolvingSpy: FlagResolving {
+    var stubbedValues = [String: Bool]()
+
+    var invokedIsEnabled = false
+    var invokedIsEnabledCount = 0
+    var invokedIsEnabledParameters: (key: String, defaultValue: Bool)?
+
+    func isEnabled(
+        _ key: String,
+        default defaultValue: Bool
+    ) -> Bool {
+        invokedIsEnabled = true
+        invokedIsEnabledCount += 1
+        invokedIsEnabledParameters = (key, defaultValue)
+
+        return stubbedValues[key] ?? defaultValue
+    }
+}

--- a/Tests/TrackingEngineTests/RemoteConfigFacadeTests.swift
+++ b/Tests/TrackingEngineTests/RemoteConfigFacadeTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import TrackingEngineCore
+
+final class RemoteConfigFacadeTests: XCTestCase {
+    override func tearDown() {
+        RemoteConfigFacade.provider = nil
+        super.tearDown()
+    }
+
+    func test_withNoProviderWired_everyFlagResolvesToItsCallerDefault() {
+        // Given — a test host that links only TrackingEngineCore and never calls setup
+        RemoteConfigFacade.provider = nil
+        let sut = RemoteConfigFacade.self
+
+        // Verify — both directions, so a hardcoded `false` can't pass this
+        XCTAssertTrue(sut.isEnabled(
+            "ff_anything",
+            default: true
+        ))
+        XCTAssertFalse(sut.isEnabled(
+            "ff_anything",
+            default: false
+        ))
+    }
+
+    func test_aWiredProviderAnswersInstead_andSeesTheDefaultItWasAskedWith() throws {
+        // Given
+        let resolverSpy = FlagResolvingSpy()
+        resolverSpy.stubbedValues = ["ff_challengeUniversalLinks": true]
+        let sut = RemoteConfigFacade.self
+        sut.configure(with: resolverSpy)
+
+        // When
+        let enabled = sut.isEnabled(
+            "ff_challengeUniversalLinks",
+            default: false
+        )
+
+        // Verify — the default must reach the resolver, which is the only way it
+        // can distinguish "console says false" from "console has never heard of this"
+        XCTAssertTrue(
+            enabled,
+            "A wired provider must win over the baked-in default"
+        )
+        let asked = try XCTUnwrap(resolverSpy.invokedIsEnabledParameters)
+        XCTAssertEqual(
+            asked.key,
+            "ff_challengeUniversalLinks"
+        )
+        XCTAssertFalse(asked.defaultValue)
+    }
+
+    func test_aProviderWithoutTheKey_fallsBackRatherThanInventingFalse() {
+        // Given — the resolver knows nothing about this flag
+        let sut = RemoteConfigFacade.self
+        sut.configure(with: FlagResolvingSpy())
+
+        // Verify — this is the whole failure mode `RemoteConfigResolver` guards
+        // against with its `.static` source check
+        XCTAssertTrue(sut.isEnabled(
+            "ff_unknown",
+            default: true
+        ))
+    }
+}


### PR DESCRIPTION
## Why

MatchWord shipped a `FeatureFlag` catalogue (PR #105 there) with nothing behind it: `FeatureFlags.isEnabled` returns the baked-in default, so a flag shipping `false` is a compile-time constant and no console toggle can turn it on. This is the half that makes those flags real. It is a release blocker for that app's Tier 0.5 challenge-links work, which ships gated on `ff_challengeUniversalLinks`.

## Shape

Mirrors `TrackingLoggable` / `TrackingEngineFacade` exactly, across the same two products:

| Product | Adds |
|---|---|
| `TrackingEngineCore` (no Firebase) | `FlagResolving` protocol, `RemoteConfigFacade` |
| `TrackingEngine` (+Firebase) | `RemoteConfigResolver`, `RemoteConfigFacade.setup(defaults:minimumFetchInterval:)` |

`RemoteConfigFacade.provider` stays `nil` until `setup` assigns one, and every read falls through to the caller's default meanwhile. That is what lets a host app's test target link only `TrackingEngineCore`, never call `setup`, and still resolve every flag — with Firebase absent from the test process, exactly as `logger == nil` already does for analytics.

Adds the `FirebaseRemoteConfig` product to the `TrackingEngine` target. No change to any existing type.

## Three decisions worth reviewing

**The resolver checks `configValue.source != .static`.** Remote Config answers `false` for a key it has never heard of. Reading that straight would silently override a caller asking for `default: true`, and the symptom would be a flag that simply looks off — indistinguishable from a working one. `.static` means neither fetched nor seeded, and is the only reliable "no answer" signal.

**The provider is assigned before `fetchAndActivate`, not in its completion.** Flags stay readable during launch (answering from the seeded defaults) and become console-backed the moment activation lands. Assigning in the callback would leave every flag unreadable for the first stretch of the app's life and write a mutable static from a background queue for no gain.

**`minimumFetchInterval` is an argument, not a `#if DEBUG`.** Firebase's own default is 12h, which is right for release and useless while developing — a console toggle appears to do nothing for half a day, and you go looking for a bug in the wiring. `DEBUG` is reliably defined in an app target and only *usually* in a package target, so the knob lives where the caller can set it correctly. Default matches Firebase's 12h; hosts pass `0` from DEBUG.

## Verification

`xcodebuild test -scheme TrackingEngine-Package` on an iOS 26.5 simulator — **5/5**, the 3 new ones covering: no provider → caller's default in *both* directions (so a hardcoded `false` can't pass), a wired provider winning and receiving the default it was asked with, and an unknown key falling back rather than resolving `false`.

Note `swift build` on the host fails for macOS on all three Firebase products, including the two that were already here — the package declares only an iOS platform. Not new, and not something this PR should fix.

The Firebase-touching half (`RemoteConfigResolver`, `setup`) has no unit coverage: constructing a `RemoteConfig` needs a configured `FirebaseApp`. It gets exercised by the host app's first real flag flip, which is the check that matters anyway — a green suite here would say nothing about whether a console value reaches the app.

## Host wiring this enables

```swift
RemoteConfigFacade.setup(defaults: FeatureFlag.remoteDefaults)   // in setupSDKs()
RemoteConfigFacade.isEnabled(flag.remoteKey, default: flag.defaultValue)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014wfActXVX1xV1Ko2bWPiWo
