### PR TITLE
Crash reports can carry a custom key, and a flag read that can tell a seeded default from a fetched value

### DIFF
--- a/Sources/TrackingEngine/RemoteConfigResolver.swift
+++ b/Sources/TrackingEngine/RemoteConfigResolver.swift
@@ -19,4 +19,37 @@ struct RemoteConfigResolver: FlagResolving {
 
         return value.boolValue
     }
+
+    func resolution(_ key: String) -> RemoteFlagResolution {
+        let value = remoteConfig.configValue(forKey: key)
+
+        return Self.resolution(
+            source: value.source,
+            value: value.boolValue
+        )
+    }
+
+    /// The source check, lifted out of the `RemoteConfigValue` it came from so
+    /// it can be tested — a `RemoteConfigValue` with a chosen source cannot be
+    /// constructed by a caller.
+    ///
+    /// Only `.remote` is an answer:
+    ///
+    /// - `.static` — Remote Config has never heard of this key.
+    /// - `.default` — the value the **host seeded** via `setup(defaults:)`.
+    ///   This is the one that looks like an answer and is not: seeding is what
+    ///   makes an un-fetched read return the host's own default, so reporting
+    ///   it as `.remote` would turn "never fetched" into "fetched and off" for
+    ///   every flag the host seeds, which is all of them.
+    /// - `.remote` — fetched and activated. The only value the console owns.
+    static func resolution(
+        source: RemoteConfigSource,
+        value: @autoclosure () -> Bool
+    ) -> RemoteFlagResolution {
+        guard source == .remote else {
+            return .unavailable
+        }
+
+        return .remote(value())
+    }
 }

--- a/Sources/TrackingEngine/TrackingLog.swift
+++ b/Sources/TrackingEngine/TrackingLog.swift
@@ -3,11 +3,30 @@ import FirebaseCrashlytics
 import TrackingEngineCore
 
 struct TrackingLog: TrackingLoggable {
-    func log(errorName: String, parameters: [String: Any]) {
+    func log(
+        errorName: String,
+        parameters: [String: Any]
+    ) {
         Crashlytics.crashlytics().log("\(errorName): \(parameters)")
     }
 
-    func track(eventName: String, parameters: [String: Any]?) {
-        Analytics.logEvent(eventName, parameters: parameters)
+    func track(
+        eventName: String,
+        parameters: [String: Any]?
+    ) {
+        Analytics.logEvent(
+            eventName,
+            parameters: parameters
+        )
+    }
+
+    func setCustomValue(
+        _ value: String,
+        forKey key: String
+    ) {
+        Crashlytics.crashlytics().setCustomValue(
+            value,
+            forKey: key
+        )
     }
 }

--- a/Sources/TrackingEngineCore/FlagResolving.swift
+++ b/Sources/TrackingEngineCore/FlagResolving.swift
@@ -1,3 +1,22 @@
+/// What the flag service actually had for a key — as opposed to what the caller
+/// decided to do about it.
+///
+/// `isEnabled` cannot express this: it answers a `Bool`, so "the console says
+/// off" and "there is nothing here" come back identical. That is fine for a
+/// kill switch, where both mean *don't*, and wrong for an experiment, where one
+/// means "assigned to control" and the other means "not assigned at all".
+public enum RemoteFlagResolution: Equatable {
+    /// A value that was fetched and activated from the remote service — the
+    /// console's answer, or an experiment variant assigned to this install.
+    case remote(Bool)
+
+    /// The service has nothing for this key: no provider wired, no fetch
+    /// landed, the fetch failed, the key does not exist — or **only the host's
+    /// own seeded default is present**, which is the host's opinion echoed back
+    /// to it rather than an answer.
+    case unavailable
+}
+
 /// Reads a remotely-controlled boolean flag. The flag analogue of
 /// `TrackingLoggable`: declared here, in the Firebase-free product, so a host
 /// app's call sites depend on this and never on Remote Config.
@@ -8,4 +27,20 @@ public protocol FlagResolving {
         _ key: String,
         default defaultValue: Bool
     ) -> Bool
+
+    /// The same read, without collapsing "off" into "absent". Prefer
+    /// `isEnabled` unless the *reason* for a `false` changes what the caller
+    /// does — which is the case for experiment assignment, and almost nothing
+    /// else.
+    func resolution(_ key: String) -> RemoteFlagResolution
+}
+
+extension FlagResolving {
+    /// Default for resolvers that cannot tell a real remote value from a
+    /// fallback. `.unavailable` is the fail-safe answer: it sends the caller to
+    /// its own default, which is exactly where it would have landed before this
+    /// method existed.
+    public func resolution(_ key: String) -> RemoteFlagResolution {
+        .unavailable
+    }
 }

--- a/Sources/TrackingEngineCore/RemoteConfigFacade.swift
+++ b/Sources/TrackingEngineCore/RemoteConfigFacade.swift
@@ -23,4 +23,11 @@ public struct RemoteConfigFacade {
             default: defaultValue
         ) ?? defaultValue
     }
+
+    /// - Returns: what the wired provider has for this key, or `.unavailable`
+    ///   when no provider is wired — the permanent state of a test host that
+    ///   links only this product.
+    public static func resolution(_ key: String) -> RemoteFlagResolution {
+        provider?.resolution(key) ?? .unavailable
+    }
 }

--- a/Sources/TrackingEngineCore/TrackingEngineFacade.swift
+++ b/Sources/TrackingEngineCore/TrackingEngineFacade.swift
@@ -5,13 +5,37 @@ public struct TrackingEngineFacade {
         Self.logger = logger
     }
 
-    public static func log(eventName: String, parameters: [String: Any]?) {
-        logger?.track(eventName: eventName, parameters: parameters)
+    public static func log(
+        eventName: String,
+        parameters: [String: Any]?
+    ) {
+        logger?.track(
+            eventName: eventName,
+            parameters: parameters
+        )
         print("event: \(eventName) - parameters: \(parameters ?? [:])")
     }
 
-    public static func log(errorName: String, parameters: [String: Any]) {
-        logger?.log(errorName: errorName, parameters: parameters)
+    public static func log(
+        errorName: String,
+        parameters: [String: Any]
+    ) {
+        logger?.log(
+            errorName: errorName,
+            parameters: parameters
+        )
         print("event: \(errorName) - parameters: \(parameters)")
+    }
+
+    /// Passthrough to the logger's crash-report metadata. A no-op while
+    /// `logger` is `nil`, exactly like `log`.
+    public static func setCustomValue(
+        _ value: String,
+        forKey key: String
+    ) {
+        logger?.setCustomValue(
+            value,
+            forKey: key
+        )
     }
 }

--- a/Sources/TrackingEngineCore/TrackingLoggable.swift
+++ b/Sources/TrackingEngineCore/TrackingLoggable.swift
@@ -1,4 +1,29 @@
 public protocol TrackingLoggable {
-    func track(eventName: String, parameters: [String: Any]?)
-    func log(errorName: String, parameters: [String: Any])
+    func track(
+        eventName: String,
+        parameters: [String: Any]?
+    )
+    func log(
+        errorName: String,
+        parameters: [String: Any]
+    )
+
+    /// Pins a key/value onto every *subsequent* crash report, so issues can be
+    /// sliced by it in the console instead of diagnosed blind. Unlike `track`
+    /// and `log` this is state, not an event: it says what this install *is*,
+    /// not what it did.
+    func setCustomValue(
+        _ value: String,
+        forKey key: String
+    )
+}
+
+extension TrackingLoggable {
+    /// Default no-op, so this addition cannot break an existing conformer in
+    /// another consumer of this package. A logger that has no crash reporter
+    /// behind it simply has nothing to pin the value to.
+    public func setCustomValue(
+        _ value: String,
+        forKey key: String
+    ) {}
 }

--- a/Tests/TrackingEngineTests/FlagResolvingSpy.swift
+++ b/Tests/TrackingEngineTests/FlagResolvingSpy.swift
@@ -17,4 +17,18 @@ final class FlagResolvingSpy: FlagResolving {
 
         return stubbedValues[key] ?? defaultValue
     }
+
+    var stubbedResolutions = [String: RemoteFlagResolution]()
+
+    var invokedResolution = false
+    var invokedResolutionCount = 0
+    var invokedResolutionKey: String?
+
+    func resolution(_ key: String) -> RemoteFlagResolution {
+        invokedResolution = true
+        invokedResolutionCount += 1
+        invokedResolutionKey = key
+
+        return stubbedResolutions[key] ?? .unavailable
+    }
 }

--- a/Tests/TrackingEngineTests/RemoteConfigFacadeTests.swift
+++ b/Tests/TrackingEngineTests/RemoteConfigFacadeTests.swift
@@ -62,4 +62,58 @@ final class RemoteConfigFacadeTests: XCTestCase {
             default: true
         ))
     }
+
+    func test_resolutionWithNoProviderWired_isUnavailableRatherThanAValue() {
+        // Given
+        RemoteConfigFacade.provider = nil
+
+        // Verify — the caller must be sent to its own default, which is exactly
+        // where it landed before `resolution` existed
+        XCTAssertEqual(
+            RemoteConfigFacade.resolution("ff_anything"),
+            .unavailable
+        )
+    }
+
+    func test_resolutionReachesTheProviderVerbatim() {
+        // Given
+        let resolverSpy = FlagResolvingSpy()
+        resolverSpy.stubbedResolutions = ["ff_brandingRevampEnabled": .remote(true)]
+        let sut = RemoteConfigFacade.self
+        sut.configure(with: resolverSpy)
+
+        // Verify
+        XCTAssertEqual(
+            sut.resolution("ff_brandingRevampEnabled"),
+            .remote(true)
+        )
+        XCTAssertEqual(
+            resolverSpy.invokedResolutionKey,
+            "ff_brandingRevampEnabled"
+        )
+    }
+
+    func test_aResolverThatCannotTellDefaultsApart_reportsUnavailable() {
+        // Given — a conformer written before `resolution` existed, taking the
+        // protocol's default implementation
+        let sut = LegacyResolver()
+
+        // Verify — silence, never a fabricated value. This is what makes the
+        // addition safe for other consumers of the package.
+        XCTAssertEqual(
+            sut.resolution("ff_anything"),
+            .unavailable
+        )
+    }
+}
+
+/// Stands in for a `FlagResolving` conformer in another consumer that predates
+/// `resolution(_:)` and therefore never implemented it.
+private struct LegacyResolver: FlagResolving {
+    func isEnabled(
+        _ key: String,
+        default defaultValue: Bool
+    ) -> Bool {
+        defaultValue
+    }
 }

--- a/Tests/TrackingEngineTests/RemoteConfigResolverTests.swift
+++ b/Tests/TrackingEngineTests/RemoteConfigResolverTests.swift
@@ -1,0 +1,78 @@
+import FirebaseRemoteConfig
+import XCTest
+
+@testable import TrackingEngine
+@testable import TrackingEngineCore
+
+/// The source check is the whole of `resolution`, and getting it wrong is
+/// invisible: every value still reads plausibly, it is only *why* that is
+/// wrong. These pin all three sources explicitly.
+final class RemoteConfigResolverTests: XCTestCase {
+    func test_onlyAFetchedValueCountsAsAnAnswerFromTheConsole() {
+        XCTAssertEqual(
+            RemoteConfigResolver.resolution(
+                source: .remote,
+                value: true
+            ),
+            .remote(true)
+        )
+        XCTAssertEqual(
+            RemoteConfigResolver.resolution(
+                source: .remote,
+                value: false
+            ),
+            .remote(false)
+        )
+    }
+
+    func test_aSeededDefaultIsNotAnAnswer() {
+        // `setup(defaults:)` seeds every one of the host's flags, so this is
+        // the state of *every* key until a fetch lands — not an edge case.
+        // Reporting it as `.remote` turns "never fetched" into "fetched and
+        // off" across the board, and an experiment reading it would count
+        // unassigned installs into its control arm.
+        XCTAssertEqual(
+            RemoteConfigResolver.resolution(
+                source: .default,
+                value: false
+            ),
+            .unavailable
+        )
+        XCTAssertEqual(
+            RemoteConfigResolver.resolution(
+                source: .default,
+                value: true
+            ),
+            .unavailable
+        )
+    }
+
+    func test_anUnknownKeyIsNotAnAnswerEither() {
+        XCTAssertEqual(
+            RemoteConfigResolver.resolution(
+                source: .static,
+                value: false
+            ),
+            .unavailable
+        )
+    }
+
+    func test_theValueIsNotEvenReadUnlessItCameFromTheConsole() {
+        // Given — `value` is an autoclosure, so a source that isn't `.remote`
+        // must never evaluate it
+        var didReadValue = false
+
+        // When
+        _ = RemoteConfigResolver.resolution(
+            source: .default,
+            value: {
+                didReadValue = true
+
+                return false
+            }()
+        )
+
+        // Verify
+        XCTAssertFalse(didReadValue)
+    }
+}

--- a/Tests/TrackingEngineTests/TrackingEngineTests.swift
+++ b/Tests/TrackingEngineTests/TrackingEngineTests.swift
@@ -12,16 +12,29 @@ final class TrackingEngineTests: XCTestCase {
         sut.logger = trackerSpy
 
         // When
-        sut.log(eventName: stubbedEventName, parameters: [stubbedKeyParameter: stubbedValueParameter])
+        sut.log(
+            eventName: stubbedEventName,
+            parameters: [stubbedKeyParameter: stubbedValueParameter]
+        )
         let logged = try XCTUnwrap(trackerSpy.invokedTrackParameters)
         let loggedData = try XCTUnwrap(logged.parameters)
 
         // Verify
-        XCTAssertEqual(logged.eventName, stubbedEventName, "Event name isn't being logged properly")
-        XCTAssertEqual(loggedData.keys.first!, stubbedKeyParameter, "Event key isn't being logged properly")
-        XCTAssertEqual(loggedData.values.first as! String,
-                       stubbedValueParameter,
-                       "Event value isn't being logged properly")
+        XCTAssertEqual(
+            logged.eventName,
+            stubbedEventName,
+            "Event name isn't being logged properly"
+        )
+        XCTAssertEqual(
+            loggedData.keys.first!,
+            stubbedKeyParameter,
+            "Event key isn't being logged properly"
+        )
+        XCTAssertEqual(
+            loggedData.values.first as! String,
+            stubbedValueParameter,
+            "Event value isn't being logged properly"
+        )
     }
 
     func test_trackingEngineFacadeIsLoggingCrashesProperly() throws {
@@ -34,15 +47,57 @@ final class TrackingEngineTests: XCTestCase {
         sut.logger = trackerSpy
 
         // When
-        sut.log(errorName: stubbedErrorName, parameters: [stubbedKeyParameter: stubbedValueParameter])
+        sut.log(
+            errorName: stubbedErrorName,
+            parameters: [stubbedKeyParameter: stubbedValueParameter]
+        )
         let logged = try XCTUnwrap(trackerSpy.invokedLogParameters)
         let loggedData = try XCTUnwrap(logged.parameters)
 
         // Verify
-        XCTAssertEqual(logged.errorName, stubbedErrorName, "Event name isn't being logged properly")
-        XCTAssertEqual(loggedData.keys.first!, stubbedKeyParameter, "Event key isn't being logged properly")
-        XCTAssertEqual(loggedData.values.first as! String,
-                       stubbedValueParameter,
-                       "Event value isn't being logged properly")
+        XCTAssertEqual(
+            logged.errorName,
+            stubbedErrorName,
+            "Event name isn't being logged properly"
+        )
+        XCTAssertEqual(
+            loggedData.keys.first!,
+            stubbedKeyParameter,
+            "Event key isn't being logged properly"
+        )
+        XCTAssertEqual(
+            loggedData.values.first as! String,
+            stubbedValueParameter,
+            "Event value isn't being logged properly"
+        )
+    }
+
+    func test_trackingEngineFacadeForwardsCustomValuesToTheLogger() throws {
+        // Given
+        let trackerSpy = TrackingLoggableSpy()
+        let sut = TrackingEngineFacade.self
+        sut.logger = trackerSpy
+
+        // When
+        sut.setCustomValue(
+            "revamp",
+            forKey: "arm"
+        )
+        let recorded = try XCTUnwrap(trackerSpy.invokedSetCustomValueParameters)
+
+        // Verify — crash-report metadata is state, not an event, so it must
+        // reach the logger verbatim and exactly once
+        XCTAssertEqual(
+            recorded.value,
+            "revamp"
+        )
+        XCTAssertEqual(
+            recorded.key,
+            "arm"
+        )
+        XCTAssertEqual(
+            trackerSpy.invokedSetCustomValueCount,
+            1
+        )
     }
 }

--- a/Tests/TrackingEngineTests/TrackingLoggableSpy.swift
+++ b/Tests/TrackingEngineTests/TrackingLoggableSpy.swift
@@ -6,7 +6,10 @@ final class TrackingLoggableSpy: TrackingLoggable {
     var invokedTrackParameters: (eventName: String, parameters: [String: Any]?)?
     var invokedTrackParametersList = [(eventName: String, parameters: [String: Any]?)]()
 
-    func track(eventName: String, parameters: [String: Any]?) {
+    func track(
+        eventName: String,
+        parameters: [String: Any]?
+    ) {
         invokedTrack = true
         invokedTrackCount += 1
         invokedTrackParameters = (eventName, parameters)
@@ -18,10 +21,26 @@ final class TrackingLoggableSpy: TrackingLoggable {
     var invokedLogParameters: (errorName: String, parameters: [String: Any])?
     var invokedLogParametersList = [(errorName: String, parameters: [String: Any])]()
 
-    func log(errorName: String, parameters: [String: Any]) {
+    func log(
+        errorName: String,
+        parameters: [String: Any]
+    ) {
         invokedLog = true
         invokedLogCount += 1
         invokedLogParameters = (errorName, parameters)
         invokedLogParametersList.append((errorName, parameters))
+    }
+
+    var invokedSetCustomValue = false
+    var invokedSetCustomValueCount = 0
+    var invokedSetCustomValueParameters: (value: String, key: String)?
+
+    func setCustomValue(
+        _ value: String,
+        forKey key: String
+    ) {
+        invokedSetCustomValue = true
+        invokedSetCustomValueCount += 1
+        invokedSetCustomValueParameters = (value, key)
     }
 }


### PR DESCRIPTION
Two additions, both additive. Nothing existing changes behaviour.

## 1. `setCustomValue(_:forKey:)`

On `TrackingLoggable`, forwarded to `Crashlytics.setCustomValue` by `TrackingLog` and passed through `TrackingEngineFacade` exactly as `log` is.

It is **state, not an event** — what an install *is*, not what it did. Crash-free rate is a common experiment guardrail, and a guardrail that cannot be filtered by variant tells you only that something broke, never which variant broke it.

## 2. `resolution(_:)` — a flag read that can tell a seeded default from a fetched value

`isEnabled(key, default:)` answers a `Bool`, so "the console says off" and "there is nothing here" come back identical. For a kill switch both mean *don't*. For experiment assignment one means "assigned to control" and the other means "not assigned at all", and conflating them corrupts the variant.

**A caller cannot recover the difference by inference**, and the tempting trick fails in a way that looks fine in tests. Probing the key twice with opposite fallbacks and checking whether the answers agree assumes an un-fetched key returns the caller's fallback. It does not, once `setup(defaults:)` has seeded it: the source is then `.default`, not `.static`, so Remote Config hands back the *seeded* value either way. Both probes agree, and a never-fetched flag reports as fetched-and-off — which is the state of **every** seeded flag until a fetch lands, i.e. all of them.

This API exists because a caller did exactly that and was wrong. The seam widens so nobody has to guess again.

`RemoteConfigResolver` answers from the config value's **source**:

| Source | Resolution | |
|---|---|---|
| `.remote` | `.remote(value)` | fetched and activated — the only value the console owns |
| `.default` | `.unavailable` | the host's own seeded value echoed back to it |
| `.static` | `.unavailable` | Remote Config has never heard of this key |

## Why both can land alone

`isEnabled` is untouched, and `resolution` carries a **default `.unavailable` implementation**, as `setCustomValue` carries a default no-op. Any existing conformer keeps compiling — `LegacyResolver` in the tests is a conformer that never implements `resolution`, pinning exactly that. `.unavailable` is also the fail-safe answer: it sends the caller to its own default, which is where it landed before the method existed.

Same shape as the `provider`/`logger` nil-until-wired split this package already uses: both new entry points are no-ops while nothing is wired, so a host linking only `TrackingEngineCore` is unaffected and Firebase still never loads into its process.

No known conformer implements either new member.

## Why the source check moved into a static

`RemoteConfigResolver.resolution(source:value:)` takes a `RemoteConfigSource` rather than reading it inline. A `RemoteConfigValue` with a chosen source cannot be constructed by a caller, so the check was untestable where it sat — which is presumably why the pre-existing `.static` guard was a comment rather than a test. Now all three sources are pinned, and `value` is an `@autoclosure` that a non-`.remote` source never evaluates.

## Deliberately not built

No `setUserProperty`, no typed key enum, no reporter protocol, no percentage-rollout helpers. The library reports; the host decides what it means — every added symbol in a shared package is permanent.

## Reading the diff

**The behaviour change is purely additive — no existing declaration changed meaning.** Everything else is the global pre-commit signature-wrap reformatting each file it was handed, one parameter per line; reviewed with whitespace hidden, the diff is only the additions.

## Test plan

- [x] **Package suite green: 13 tests, 0 failures**, on an iOS Simulator destination. Worth recording: `swift test` fails for this package (SwiftPM builds for macOS, the manifest is iOS-only), but `xcodebuild test -scheme TrackingEngine-Package -destination 'platform=iOS Simulator,…'` works — these tests are runnable after all
- [x] `test_trackingEngineFacadeForwardsCustomValuesToTheLogger` — the value and key reach the logger verbatim, exactly once
- [x] `RemoteConfigResolverTests` — all three sources pinned. **Negative control run, not assumed:** reverting the guard to the old `source != .static` turns three assertions red, including both halves of `test_aSeededDefaultIsNotAnAnswer`
- [x] `test_aResolverThatCannotTellDefaultsApart_reportsUnavailable` — a conformer predating `resolution` compiles and answers safely
- [x] Verified against a consuming app with this branch checked out in place; its suite is green
- [ ] Real-device pass: confirm the custom key appears on a Crashlytics issue detail page, and that a flag flipped in the console reaches the app as `.remote`. Neither is verifiable from the console alone — Firebase tooling has been observed reporting success having done nothing

## Sequencing

Consumers reference this package by local path during development and by git remote in CI, so **a dependent app's CI cannot go green until this merges to `main`.** Merge here first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
