### PR TITLE
feat: user properties, and a way back into DebugView when collection is off

### DIFF
--- a/Sources/TrackingEngine/TrackingEngineFacade+Firebase.swift
+++ b/Sources/TrackingEngine/TrackingEngineFacade+Firebase.swift
@@ -1,11 +1,24 @@
 import Firebase
+import FirebaseAnalytics
 import TrackingEngineCore
 
 extension TrackingEngineFacade {
-    public static func setup() {
+    /// - Parameter forcingAnalyticsCollection: `nil` leaves collection to
+    ///   `FIREBASE_ANALYTICS_COLLECTION_ENABLED` in the app's `Info.plist`, which is the
+    ///   shipping answer. A non-`nil` value writes Firebase's **persisted** runtime override.
+    ///
+    ///   That override survives relaunches, which is why the caller passes a `Bool` rather
+    ///   than only opting in: a build that opts in once and is then launched without the
+    ///   argument must go quiet again, and only an explicit `false` does that.
+    public static func setup(
+        forcingAnalyticsCollection: Bool? = nil
+    ) {
         FirebaseConfiguration.shared.setLoggerLevel(.min)
         if FirebaseApp.app() == nil {
             FirebaseApp.configure()
+        }
+        if let forcingAnalyticsCollection {
+            Analytics.setAnalyticsCollectionEnabled(forcingAnalyticsCollection)
         }
         configure(with: TrackingLog())
     }

--- a/Sources/TrackingEngine/TrackingLog.swift
+++ b/Sources/TrackingEngine/TrackingLog.swift
@@ -29,4 +29,14 @@ struct TrackingLog: TrackingLoggable {
             forKey: key
         )
     }
+
+    func setUserProperty(
+        _ value: String?,
+        forName name: String
+    ) {
+        Analytics.setUserProperty(
+            value,
+            forName: name
+        )
+    }
 }

--- a/Sources/TrackingEngineCore/TrackingEngineFacade.swift
+++ b/Sources/TrackingEngineCore/TrackingEngineFacade.swift
@@ -38,4 +38,16 @@ public struct TrackingEngineFacade {
             forKey: key
         )
     }
+
+    /// Passthrough to the logger's user-scoped analytics properties. A no-op while
+    /// `logger` is `nil`, exactly like `log`.
+    public static func setUserProperty(
+        _ value: String?,
+        forName name: String
+    ) {
+        logger?.setUserProperty(
+            value,
+            forName: name
+        )
+    }
 }

--- a/Sources/TrackingEngineCore/TrackingLoggable.swift
+++ b/Sources/TrackingEngineCore/TrackingLoggable.swift
@@ -16,6 +16,17 @@ public protocol TrackingLoggable {
         _ value: String,
         forKey key: String
     )
+
+    /// Pins a key/value onto every *subsequent* analytics event **and** the user record
+    /// behind it, so audiences, Remote Config conditions and A/B test exclusions can be
+    /// keyed on it. Like `setCustomValue` this is state rather than an event.
+    ///
+    /// ⚠️ It is **not retroactive within a session**: events already queued when it is
+    /// called — `first_open` and the first `session_start` — land untagged.
+    func setUserProperty(
+        _ value: String?,
+        forName name: String
+    )
 }
 
 extension TrackingLoggable {
@@ -25,5 +36,11 @@ extension TrackingLoggable {
     public func setCustomValue(
         _ value: String,
         forKey key: String
+    ) {}
+
+    /// Default no-op, for the same reason as `setCustomValue` above.
+    public func setUserProperty(
+        _ value: String?,
+        forName name: String
     ) {}
 }


### PR DESCRIPTION
## Summary

production analytics could not tell a real user from a simulator, a TestFlight tester or an E2E run. Both go behind the seams that already exist rather than beside them.

## Changes

- **`TrackingLoggable.setUserProperty(_:forName:)`** — joins `track` and `setCustomValue`, with a default no-op so no existing conformer breaks. The Firebase side calls `Analytics.setUserProperty`. The consumer sends `distribution = testflight | appstore`, which is what a GA4 audience, a Remote Config condition and an A/B test exclusion are keyed on.
- **`TrackingEngineFacade.setUserProperty(_:forName:)`** — the passthrough, a no-op while `logger` is `nil`, exactly like `log`.
- **`TrackingEngineFacade.setup(forcingAnalyticsCollection:)`** — an optional `Bool`. `nil` (the default, and the existing behaviour) leaves collection to `FIREBASE_ANALYTICS_COLLECTION_ENABLED` in the app's `Info.plist`. A non-`nil` value writes Firebase's runtime override.

  It takes a `Bool` rather than being a bare opt-in flag **because that override is persisted**: a build launched once with the argument and then without it has to be able to go quiet again, and only an explicit `false` does that.

## Test plan

### Already run — evidence, not a request

- [x] Consumer's suite green with it: **960 tests, 1 skipped, 0 failures**.
- [x] `setup(forcingAnalyticsCollection:)` exercised in both directions on a simulator, read off the persisted flag **after terminating** the app: `/google/measurement/measurement_enabled_state` = `1` (enabled) with the consumer's opt-in argument, `2` (disabled) without it. Both argument spellings, dashed and bare.
- [x] `setUserProperty` confirmed on the wire in GA4 DebugView — `distribution = appstore` under *User Properties Active Now*, against property `308576907`.
- [x] Negative control for the pair above: the identical UI actions with the opt-in absent delivered **no events at all** (DebugView total unchanged, current minute 0).

### Needs you

- [ ] **Confirm the API shape is what you want before this becomes public surface.** `setup(forcingAnalyticsCollection:)` is source-compatible (the parameter is defaulted), but it is a published entry point in a package with other consumers — that is a judgement call, not something a test settles.
- [ ] **The `testflight` half of what this enables cannot be verified anywhere local.** No local build of any configuration produces a `sandboxReceipt`; a simulator reports the App Store receipt name. First real confirmation is a TestFlight install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
