### PR TITLE
feat: one call that says who every event and crash belongs to

### DIFF
--- a/Sources/TrackingEngine/TrackingLog.swift
+++ b/Sources/TrackingEngine/TrackingLog.swift
@@ -39,4 +39,12 @@ struct TrackingLog: TrackingLoggable {
             forName: name
         )
     }
+
+    /// Both sinks, from one call, deliberately: analytics answers "how many people", crash
+    /// reporting answers "how many people hit this crash", and the second question is only
+    /// answerable if it is keyed on the same id as the first.
+    func setUserID(_ id: String?) {
+        Analytics.setUserID(id)
+        Crashlytics.crashlytics().setUserID(id)
+    }
 }

--- a/Sources/TrackingEngineCore/TrackingEngineFacade.swift
+++ b/Sources/TrackingEngineCore/TrackingEngineFacade.swift
@@ -50,4 +50,11 @@ public struct TrackingEngineFacade {
             forName: name
         )
     }
+
+    /// Passthrough to the logger's user identity, which it fans out to every sink it has.
+    /// A no-op while `logger` is `nil`, exactly like `log` — and worth knowing that a call
+    /// made before `configure(with:)` is silently dropped rather than queued.
+    public static func setUserID(_ id: String?) {
+        logger?.setUserID(id)
+    }
 }

--- a/Sources/TrackingEngineCore/TrackingLoggable.swift
+++ b/Sources/TrackingEngineCore/TrackingLoggable.swift
@@ -27,6 +27,26 @@ public protocol TrackingLoggable {
         _ value: String?,
         forName name: String
     )
+
+    /// Identifies *who* every subsequent analytics event and crash report belongs to, so
+    /// counts and cohorts are computed per person rather than per install. Like
+    /// `setCustomValue` and `setUserProperty` this is state, not an event.
+    ///
+    /// **One call reaches every sink a conformer has.** An id that is set in one console
+    /// and missing in another is worse than no id at all: the two disagree and neither is
+    /// obviously wrong. A caller that has to remember a second call is one that will make
+    /// half of them.
+    ///
+    /// The library neither mints nor stores the value — **durability is the caller's
+    /// problem.** An id that is regenerated per install identifies an install, and passing
+    /// one here buys nothing.
+    ///
+    /// ⚠️ Not retroactive, within a session or across history: events already queued when
+    /// it is called land unattributed, and events recorded before it first shipped are
+    /// never re-labelled.
+    ///
+    /// - Parameter id: `nil` clears the identity, which is how a conformer forgets a user.
+    func setUserID(_ id: String?)
 }
 
 extension TrackingLoggable {
@@ -43,4 +63,8 @@ extension TrackingLoggable {
         _ value: String?,
         forName name: String
     ) {}
+
+    /// Default no-op, for the same reason as `setCustomValue` above. A conformer with no
+    /// user-scoped sink behind it has nobody to attribute anything to.
+    public func setUserID(_ id: String?) {}
 }

--- a/Tests/TrackingEngineTests/TrackingEngineTests.swift
+++ b/Tests/TrackingEngineTests/TrackingEngineTests.swift
@@ -100,4 +100,68 @@ final class TrackingEngineTests: XCTestCase {
             1
         )
     }
+
+    func test_trackingEngineFacadeForwardsTheUserIdentityToTheLogger() throws {
+        // Given
+        let trackerSpy = TrackingLoggableSpy()
+        let sut = TrackingEngineFacade.self
+        sut.logger = trackerSpy
+
+        // When
+        sut.setUserID("57C8D2E4-0000-4B1A-9E3F-000000000001")
+
+        // Verify — verbatim and exactly once: an id the facade edits, truncates or
+        // re-sends is an id that no longer matches the one the caller can be asked for
+        XCTAssertEqual(
+            try XCTUnwrap(trackerSpy.invokedSetUserIDParameter),
+            "57C8D2E4-0000-4B1A-9E3F-000000000001"
+        )
+        XCTAssertEqual(
+            trackerSpy.invokedSetUserIDCount,
+            1
+        )
+    }
+
+    func test_trackingEngineFacadeForwardsAClearedUserIdentity() throws {
+        // Given
+        let trackerSpy = TrackingLoggableSpy()
+        let sut = TrackingEngineFacade.self
+        sut.logger = trackerSpy
+
+        // When
+        sut.setUserID(nil)
+
+        // Verify — the negative control. `nil` is how a conformer forgets a user, so it
+        // has to travel rather than be swallowed as "nothing to do"
+        XCTAssertEqual(
+            trackerSpy.invokedSetUserIDCount,
+            1
+        )
+        XCTAssertNil(
+            try XCTUnwrap(trackerSpy.invokedSetUserIDParameter)
+        )
+    }
+
+    func test_aBareConformerCompilesAndItsDefaultsAreInert() {
+        // Given a conformer that implements only the two required members
+        let sut = BareTrackingLoggable()
+
+        // When — every optional member is reachable through the default extension
+        sut.setUserID("ignored")
+        sut.setUserProperty(
+            "ignored",
+            forName: "ignored"
+        )
+        sut.setCustomValue(
+            "ignored",
+            forKey: "ignored"
+        )
+
+        // Verify — the compile is half the pin; the other half is that no default
+        // quietly routes itself into a required member behind the conformer's back
+        XCTAssertFalse(
+            sut.recordedSomething,
+            "A no-op default reached `track` or `log`"
+        )
+    }
 }

--- a/Tests/TrackingEngineTests/TrackingLoggableSpy.swift
+++ b/Tests/TrackingEngineTests/TrackingLoggableSpy.swift
@@ -43,4 +43,38 @@ final class TrackingLoggableSpy: TrackingLoggable {
         invokedSetCustomValueCount += 1
         invokedSetCustomValueParameters = (value, key)
     }
+
+    var invokedSetUserID = false
+    var invokedSetUserIDCount = 0
+    var invokedSetUserIDParameter: String??
+
+    func setUserID(_ id: String?) {
+        invokedSetUserID = true
+        invokedSetUserIDCount += 1
+        invokedSetUserIDParameter = id
+    }
+}
+
+/// A conformer that implements **only** the two required members. Its existence is the
+/// proof that every later addition to `TrackingLoggable` carries a working default: this
+/// file stops compiling the moment one of them becomes a requirement, which is a louder
+/// failure than a comment promising the same thing.
+final class BareTrackingLoggable: TrackingLoggable {
+    /// Flipped by either required member, so a default implementation that quietly routed
+    /// itself into `track` or `log` would be caught rather than assumed absent.
+    var recordedSomething = false
+
+    func track(
+        eventName: String,
+        parameters: [String: Any]?
+    ) {
+        recordedSomething = true
+    }
+
+    func log(
+        errorName: String,
+        parameters: [String: Any]
+    ) {
+        recordedSomething = true
+    }
 }


### PR DESCRIPTION
## Summary

Adds `setUserID` so a caller can say **who** every subsequent analytics event and crash report belongs to. Without it, analytics keyed on an app-instance id counts installs rather than people: a reinstall reads as a new user forever, and retention cohorts get computed on an identity that by construction cannot survive one.

Additive and no-op by default, so nothing that already conforms to `TrackingLoggable` changes.

## Changes

**TrackingEngineCore**

- `TrackingLoggable.setUserID(_ id: String?)`, with a default no-op in the protocol extension — a conformer with no user-scoped sink has nobody to attribute anything to.
- `TrackingEngineFacade.setUserID(_:)` passthrough, a no-op while `logger` is `nil` exactly like `log`. The doc comment says out loud that a call made before `configure(with:)` is dropped rather than queued.
- The doc comment also fixes the two boundaries this API is easy to get wrong at: the library **neither mints nor stores** the value (an id regenerated per install identifies an install, and passing one here buys nothing), and it is **not retroactive** — events already queued land unattributed, and history is never re-labelled.

**TrackingEngine (Firebase)**

- `TrackingLog.setUserID` calls `Analytics.setUserID` **and** `Crashlytics.setUserID`. One call, both sinks, deliberately: an id present in one console and missing from the other is worse than no id, because the two disagree and neither is obviously wrong — and a caller who has to remember a second call will make half of them.

**Tests**

- The spy now records `setUserID`, so the facade's passthrough is asserted rather than assumed.
- `BareTrackingLoggable` — a new conformer implementing **only** the two required members. This is the "additions land alone" pin, and it had to be its own type: the previous habit of leaving the spy un-updated cannot both pin the default *and* record the call, so the newest member always shipped with zero behavioural coverage.
- A `nil` case of its own, because clearing an identity has to travel rather than be swallowed as "nothing to do" by a passthrough that guards on the optional.

## Test plan

### Already run — evidence, not a request

- [x] Package suite, `xcodebuild test -scheme TrackingEngine-Package -destination 'platform=iOS Simulator,name=iPhone 17 Pro'` — **16 tests, 0 failures**. `TrackingEngineTests` went 3 → 6.
- [x] Confirmed all three new cases executed **by name** in the run log, not inferred from the total: `test_trackingEngineFacadeForwardsTheUserIdentityToTheLogger`, `test_trackingEngineFacadeForwardsAClearedUserIdentity`, `test_aBareConformerCompilesAndItsDefaultsAreInert`.
- [x] Forwarding is asserted verbatim and exactly once — an id the facade edits or re-sends no longer matches the one a caller can be asked to produce.
- [x] Negative control: `setUserID(nil)` reaches the logger, and the count proves it was not swallowed.
- [x] The bare conformer compiles against the widened protocol, and its flag stays `false` after all three defaults are called — so no default quietly routes itself into `track` or `log`.

### Needs you

- [ ] **Build a consuming app against this branch before merging.** Local resolution is by path and picks up edits without a commit, so "it compiles here" proves nothing about anyone else; consumers' CI clones the default branch. No consuming app was compiled against this change in the session that wrote it.
- [ ] **Confirm the id lands in both consoles.** `Analytics` and `Crashlytics` have no observable effect from a test process, so neither sink can be asserted here — it needs credentialed consoles and the usual reporting latency, and a reporting-identity setting that includes User-ID on the analytics side (on a device-based setting the call is ignored outright).

🤖 Generated with [Claude Code](https://claude.com/claude-code)