### PR TITLE
feat: carry install traits into the flag fetch, so targeting is a dashboard edit

### DIFF
--- a/Sources/TrackingEngine/RemoteConfigFacade+Firebase.swift
+++ b/Sources/TrackingEngine/RemoteConfigFacade+Firebase.swift
@@ -15,6 +15,25 @@ extension RemoteConfigFacade {
     ///   - defaults: every flag key mapped to its baked-in value. Seeding these
     ///     is what makes an un-fetched read return the app's own default rather
     ///     than Remote Config's blanket `false`.
+    ///   - traits: facts about *this install* that the remote service may branch
+    ///     on — an opaque bag the host fills and the console matches against, so
+    ///     targeting a flag at particular installs is a dashboard edit rather
+    ///     than a release. Empty by default, which is exactly the behaviour
+    ///     every existing caller already has.
+    ///
+    ///     **They are published before the fetch, and that is the whole reason
+    ///     this is a parameter rather than a method to call afterwards.** The
+    ///     service evaluates conditions against whatever traits it holds *at
+    ///     fetch time*; setting them after `setup` returns would miss the first
+    ///     fetch, and in release the next one is `defaultFetchInterval` away —
+    ///     so a targeted install would sit on the untargeted value for twelve
+    ///     hours. Passing them in makes the ordering unmissable.
+    ///
+    ///     Values are strings because that is what identity-shaped traits are.
+    ///     **A trait the console must compare *numerically* — a bucket, a
+    ///     score, a tier — is not served by this**: string comparison orders
+    ///     lexicographically, so `"9" > "50"`. Adding a numeric overload is the
+    ///     upgrade path, and it is additive whenever someone needs it.
     ///   - minimumFetchInterval: defaults to `defaultFetchInterval`, which is
     ///     right for release and useless while developing — a console toggle
     ///     appears to do nothing for half a day. Pass `0` from DEBUG builds.
@@ -23,6 +42,7 @@ extension RemoteConfigFacade {
     ///     defined in a package target, and the failure is silent either way.
     public static func setup(
         defaults: [String: Bool],
+        traits: [String: String] = [:],
         minimumFetchInterval: TimeInterval = defaultFetchInterval
     ) {
         if FirebaseApp.app() == nil {
@@ -42,6 +62,65 @@ extension RemoteConfigFacade {
         // mutable static from a background queue for no gain.
         configure(with: RemoteConfigResolver(remoteConfig: remoteConfig))
 
+        publish(
+            traits: traits,
+            setting: { traits in
+                try await remoteConfig.setCustomSignals(traits.mapValues { .string($0) })
+            },
+            thenFetching: { fetchAndActivate(remoteConfig) }
+        )
+    }
+
+    /// Publishes traits, **then** fetches — and fetches either way.
+    ///
+    /// Both effects arrive as closures for the same reason
+    /// `RemoteConfigResolver.resolution(source:value:)` is a lifted static: the
+    /// real ones configure a `FirebaseApp` and open a socket, so the ordering
+    /// that is the entire point of this function cannot otherwise be observed.
+    /// The SDK's own `CustomSignalValue` is no help either — its payload is a
+    /// private enum with no `Equatable`, so a test can neither read a signal
+    /// back nor compare two.
+    ///
+    /// - Parameters:
+    ///   - traits: empty is not a degenerate case of publishing. It is every
+    ///     caller that predates this parameter, and it reaches the fetch by
+    ///     exactly the path it always did — synchronously, no `Task`, no
+    ///     suspension inserted ahead of the flags.
+    ///   - setSignals: publishing. A throw costs *targeting* only.
+    ///   - fetch: the flag fetch, which must happen regardless. Letting a
+    ///     rejected trait swallow it would cost every flag including the kill
+    ///     switches — by far the larger failure.
+    static func publish(
+        traits: [String: String],
+        setting setSignals: @escaping ([String: String]) async throws -> Void,
+        thenFetching fetch: @escaping () -> Void
+    ) {
+        guard !traits.isEmpty else {
+            fetch()
+
+            return
+        }
+
+        Task {
+            do {
+                try await setSignals(traits)
+            } catch {
+                // The SDK rejects the whole batch on a key over 250 characters,
+                // a string value over 500, or more than 100 signals — so this
+                // is the branch a malformed trait actually takes, and it must
+                // not be silent or the console shows a condition matching
+                // nobody with nothing to explain why.
+                TrackingEngineFacade.log(
+                    errorName: "remoteConfigTraitsRejected",
+                    parameters: ["description": error.localizedDescription]
+                )
+            }
+
+            fetch()
+        }
+    }
+
+    private static func fetchAndActivate(_ remoteConfig: RemoteConfig) {
         remoteConfig.fetchAndActivate { _, error in
             if let error {
                 TrackingEngineFacade.log(

--- a/Tests/TrackingEngineTests/RemoteConfigTraitsTests.swift
+++ b/Tests/TrackingEngineTests/RemoteConfigTraitsTests.swift
@@ -1,0 +1,109 @@
+import XCTest
+
+@testable import TrackingEngine
+@testable import TrackingEngineCore
+
+/// Traits decide which installs a console condition can single out, and every
+/// way of getting this wrong is silent: the fetch still succeeds, the flags
+/// still resolve, and only the targeting quietly matches nobody — or, worse, the
+/// flags stop arriving because a rejected trait took the fetch down with it.
+final class RemoteConfigTraitsTests: XCTestCase {
+    func test_withNoTraits_theFetchHappensSynchronouslyAndNothingIsPublished() {
+        // Given — every caller that predates the `traits` parameter
+        var didSetSignals = false
+        var didFetch = false
+
+        // When
+        RemoteConfigFacade.publish(
+            traits: [:],
+            setting: { _ in didSetSignals = true },
+            thenFetching: { didFetch = true }
+        )
+
+        // Verify — asserted immediately, with no expectation and no awaiting:
+        // that is the assertion. An empty bag must not push the flag fetch
+        // behind a suspension point at every launch.
+        XCTAssertTrue(
+            didFetch,
+            "The fetch must still be synchronous for callers passing no traits"
+        )
+        XCTAssertFalse(
+            didSetSignals,
+            "Publishing an empty bag is a round-trip for nothing"
+        )
+    }
+
+    func test_traitsArePublishedBeforeTheFetch_andReachThePublisherVerbatim() {
+        // Given
+        let traits = [
+            "install_id": "ABCDEF01-2345-4678-9ABC-DEF012345678",
+            "distribution": "testflight"
+        ]
+        var published: [String: String]?
+        // A recorded *sequence*, not a pair of flags. Two flags read after the
+        // fact are last-write-wins: a double fetch sets "did publish happen
+        // first?" to false and then true, and the assertion sees only the
+        // second. Asserting the whole sequence catches the order and the
+        // duplicate with one comparison — and this test genuinely passed
+        // against a double-fetching implementation before it was written this
+        // way.
+        var events = [String]()
+        let fetched = expectation(description: "fetch")
+
+        // When
+        RemoteConfigFacade.publish(
+            traits: traits,
+            setting: {
+                published = $0
+                events.append("publish")
+            },
+            thenFetching: {
+                events.append("fetch")
+                fetched.fulfill()
+            }
+        )
+
+        // Verify
+        wait(
+            for: [fetched],
+            timeout: 1
+        )
+        XCTAssertEqual(
+            events,
+            ["publish", "fetch"],
+            "Conditions are evaluated against the traits held at fetch time — publishing "
+                + "after it means the first fetch misses them entirely, and fetching twice "
+                + "spends a second round-trip to correct the first"
+        )
+        XCTAssertEqual(
+            published,
+            traits,
+            "A condition matches the whole value; nothing may be trimmed, renamed or dropped"
+        )
+    }
+
+    func test_aRejectedTraitStillLetsTheFlagsThrough() {
+        // Given — what the SDK does to an over-long value or an over-full batch
+        let fetched = expectation(description: "fetch")
+
+        // When
+        RemoteConfigFacade.publish(
+            traits: ["install_id": String(
+                repeating: "x",
+                count: 501
+            )],
+            setting: { _ in throw TraitError.rejected },
+            thenFetching: { fetched.fulfill() }
+        )
+
+        // Verify — the whole point. Targeting is lost, the kill switches are not.
+        wait(
+            for: [fetched],
+            timeout: 1
+        )
+    }
+}
+
+private enum TraitError: Error {
+    case rejected
+}


### PR DESCRIPTION
## Summary

Lets a host hand the flag service facts about the current install, so a flag can be served to particular installs from the dashboard instead of from a release. The identifiers live in the console; the binary stays generic.

The gap this closes: the analytics identity is not something the flag service can condition on, so "turn this on for these two installs" previously had no expression at all short of shipping the identifiers in code.

## Changes

**API**
- `setup(defaults:traits:minimumFetchInterval:)` — new `traits: [String: String]` parameter, defaulted to `[:]`. Purely additive; every existing call site compiles and behaves unchanged.
- Traits are published **before** the fetch. That is why this is a parameter and not a method to call afterwards: conditions are evaluated against whatever the service holds at fetch time, so publishing after `setup` returns misses the first fetch — and in release the next is `defaultFetchInterval` (12h) away, leaving a targeted install on the untargeted value for half a day. As a parameter, a caller cannot get the ordering wrong.

**Two failure modes, decided rather than defaulted**
- **An empty bag is not a degenerate publish.** It takes the original synchronous path with no `Task`, so callers predating the parameter keep exactly the behaviour they had rather than gaining a suspension point in front of every flag.
- **A rejected batch is logged and the fetch still happens.** The SDK refuses the whole batch on a key over 250 characters, a string value over 500, or more than 100 signals. Letting that swallow the fetch would cost every flag including the kill switches — far worse than losing targeting. Reported as `remoteConfigTraitsRejected`.

**Testability**
- The sequencing takes its two effects as closures, for the same reason `RemoteConfigResolver.resolution(source:value:)` is a lifted static: the real ones configure an app and open a socket. The vendor's signal value is opaque besides — a private enum with no `Equatable` — so a test can neither read a signal back nor compare two, which leaves the ordering as the thing worth pinning.

**Known ceiling, recorded in the doc comment:** values are strings. A trait the console must compare *numerically* is not served by this, because string comparison orders lexicographically (`"9" > "50"`). A numeric overload is the upgrade path and is additive whenever someone needs it.

## Test plan

### Already run — evidence, not a request

- [x] **Package suite green: 19 tests, 0 failures** (3 new), `xcodebuild test -scheme TrackingEngine-Package -destination 'platform=iOS Simulator,name=iPhone 17 Pro'`. Re-run after the pre-commit formatter touched the test file; still 19/0.
- [x] **Every new test verified against a deliberately broken implementation**, one break at a time, each failing only its own test:
  - guard removed → `test_withNoTraits_theFetchHappensSynchronouslyAndNothingIsPublished` fails, other two pass
  - fetch moved ahead of publish → `test_traitsArePublishedBeforeTheFetch…` fails with `["fetch", "publish"]`, other two pass
  - fetch moved inside the `do` → `test_aRejectedTraitStillLetsTheFlagsThrough` fails on the unfulfilled expectation, other two pass
- [x] **The ordering test earned its current shape by failing to catch a real break.** Written first as two flags read after the fact, it passed against an implementation that called fetch twice — last-write-wins hid the bad first call. Rewritten to assert the whole event sequence, which catches the order and the duplicate together.
- [x] **Additive-ness**: the existing `RemoteConfigFacadeTests` and `RemoteConfigResolverTests` compile and pass untouched, which is the pin that the new parameter is optional at the call site.

### Needs you

- [ ] **The real publish path is not exercised by any test here.** `setCustomSignals` is only reached through the closure the production `setup` passes; the suite covers the sequencing around it, never the SDK call itself. Confirming a trait actually arrives needs a real app, a console condition and a device — it cannot be done from this package.
- [ ] **The 250/500/100 limits are read off the SDK's own constants**, not measured. Nothing here published an over-long value and observed the rejection; the test asserts only that this layer passes it through rather than pre-filtering.
- [ ] **Whether `[String: String]` is the right ceiling** is a design call. Numeric traits are a plausible near-term want and would need the overload named in the doc comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
